### PR TITLE
collect thread correctly again

### DIFF
--- a/src/collectData/utils/scrape/collectPosts/extractThreadHTML.js
+++ b/src/collectData/utils/scrape/collectPosts/extractThreadHTML.js
@@ -10,7 +10,7 @@ async function extractThreadHTML(repliesButton, page) {
     const threadHandle = await page.waitForSelector(threadSelector)
     const threadHTML = await threadHandle.evaluate(thread => thread.outerHTML)
 
-    const closeThreadButton = await page.$('[aria-label="Close Right Sidebar"]')
+    const closeThreadButton = await page.$('[aria-label="Close secondary view"]')
     await closeThreadButton.click()
 
     return threadHTML


### PR DESCRIPTION
It seems the web version of Slack had changed the property of the "X" button for the closing thread.
![image](https://user-images.githubusercontent.com/875328/229957359-8f353e07-5e43-4a35-99d4-aeaa7dd5e43f.png)

Before this change, I got this error
```
Error scraping thread. Skipping this thread. Potential Solution: If your Slack app is set to another language than English, please temporarily set it to English for the scrape. The thread selector will not work in other languages. Error: Cannot read properties of null (reading 'click').
```
And it was fixed after this change.

